### PR TITLE
resolv cli / dissectors dependency error

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Security",
 ]
 dependencies = [
-    "edf-plasma-dissectors~=2.0",
+    "edf-plasma-dissectors~=3.0",
 ]
 
 


### PR DESCRIPTION
We cannot install edf-plasma-cli v3.0.0 with edf-plasma-dissectors v 3.0.0 because of the cli pyproject requirements.
```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
edf-plasma-cli 3.0.0 requires edf-plasma-dissectors~=2.0, but you have edf-plasma-dissectors 3.0.0 which is incompatible.
```
Here a short solve